### PR TITLE
Update debian_install.sh

### DIFF
--- a/debian_install.sh
+++ b/debian_install.sh
@@ -168,8 +168,8 @@ debian_install_Virus (){
 #Install Amavisd-new, SpamAssassin, And Clamav
 apt-get -y install amavisd-new spamassassin clamav clamav-daemon zoo unzip bzip2 arj nomarch lzop cabextract apt-listchanges libnet-ldap-perl libauthen-sasl-perl clamav-docs daemon libio-string-perl libio-socket-ssl-perl libnet-ident-perl zip libnet-dns-perl
 
-/etc/init.d/spamassassin stop
-update-rc.d -f spamassassin remove
+sed -i 's|ENABLED=0| ENABLED=1|' /etc/default/spamassassin
+insserv -rf spamassassin
 
 }
 


### PR DESCRIPTION
- SpamAssassin is disabled by default on Debian 7, The ISPConfig 3 setup uses amavisd which loads the SpamAssassin filter library internally..

As of 7.1 (Debian Wheezy), dependency based boot is used by default, instead of:

update-rc.d -f spamassassin remove

you would use:

insserv -rf spamassassin

otherwise you get a lil message:

update-rc.d: using dependency based boot sequencing

and the init.rc isn't updated.
